### PR TITLE
fix: remove push restrictions for all repos in enarx org

### DIFF
--- a/github_branchprotections_enarx.tf
+++ b/github_branchprotections_enarx.tf
@@ -9,9 +9,6 @@ resource "github_branch_protection" "enarx-flagset-_wild_" {
   require_signed_commits          = false
   required_linear_history         = false
   require_conversation_resolution = false
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -50,9 +47,6 @@ resource "github_branch_protection" "enarx-enarx-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = [
-      "/enarxbot",
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -108,7 +102,6 @@ resource "github_branch_protection" "enarx-enarx-archive" {
   require_signed_commits          = true
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -138,10 +131,6 @@ resource "github_branch_protection" "enarx-enarx-chore_slash_rust-update-workflo
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = [
-      "/enarxbot",
-      github_team.enarx-admin.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -157,10 +146,6 @@ resource "github_branch_protection" "enarx-enarx-chore_slash_cargo-update" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = [
-      "/platten",
-      "/enarxbot",
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -176,7 +161,6 @@ resource "github_branch_protection" "enarx-enarx-b0_4_z" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -201,7 +185,6 @@ resource "github_branch_protection" "enarx-enarx-release_slash__wild_" {
   require_signed_commits          = true
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = []
   allows_deletions                = true
   allows_force_pushes             = false
   blocks_creations                = false
@@ -226,7 +209,6 @@ resource "github_branch_protection" "enarx-enarx-nix-update" {
   require_signed_commits          = false
   required_linear_history         = false
   require_conversation_resolution = false
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = true
   blocks_creations                = false
@@ -242,7 +224,6 @@ resource "github_branch_protection" "enarx-_github-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -272,9 +253,6 @@ resource "github_branch_protection" "enarx-iocuddle-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -316,9 +294,6 @@ resource "github_branch_protection" "enarx-nbytes-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -360,9 +335,6 @@ resource "github_branch_protection" "enarx-crt0stack-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -404,9 +376,6 @@ resource "github_branch_protection" "enarx-vdso-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -446,9 +415,6 @@ resource "github_branch_protection" "enarx-xsave-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -484,9 +450,6 @@ resource "github_branch_protection" "enarx-lset-main" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -526,9 +489,6 @@ resource "github_branch_protection" "enarx-mmarinus-main" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -574,9 +534,6 @@ resource "github_branch_protection" "enarx-primordial-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -606,9 +563,6 @@ resource "github_branch_protection" "enarx-sgx-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -644,9 +598,6 @@ resource "github_branch_protection" "enarx-ciborium-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = [
-      github_team.enarx-bots.node_id,
-    ]
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -676,7 +627,6 @@ resource "github_branch_protection" "enarx-rcrt1-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -706,7 +656,6 @@ resource "github_branch_protection" "enarx-snp-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -747,7 +696,6 @@ resource "github_branch_protection" "enarx-noted-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -777,7 +725,6 @@ resource "github_branch_protection" "enarx-website-main" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -809,7 +756,6 @@ resource "github_branch_protection" "enarx-website-staging" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = true
   blocks_creations                = false
@@ -825,7 +771,6 @@ resource "github_branch_protection" "enarx-mmledger-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = true
   blocks_creations                = false
@@ -867,7 +812,6 @@ resource "github_branch_protection" "enarx-testaso-main" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -897,7 +841,6 @@ resource "github_branch_protection" "enarx-cryptle-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -929,7 +872,6 @@ resource "github_branch_protection" "enarx-codex-main" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -968,7 +910,6 @@ resource "github_branch_protection" "enarx-GreenhouseMonitor-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = false
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = true
   blocks_creations                = false
@@ -984,7 +925,6 @@ resource "github_branch_protection" "enarx-vscode-enarx-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -1009,7 +949,6 @@ resource "github_branch_protection" "enarx-vfs-main" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -1046,7 +985,6 @@ resource "github_branch_protection" "enarx-vfs-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false
@@ -1076,7 +1014,6 @@ resource "github_branch_protection" "enarx-vfs-nix-update" {
   require_signed_commits          = false
   required_linear_history         = false
   require_conversation_resolution = false
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = true
   blocks_creations                = false
@@ -1092,7 +1029,6 @@ resource "github_branch_protection" "enarx-wasi-tests-_wild_" {
   require_signed_commits          = false
   required_linear_history         = true
   require_conversation_resolution = true
-  push_restrictions               = []
   allows_deletions                = false
   allows_force_pushes             = false
   blocks_creations                = false


### PR DESCRIPTION
Signed-off-by: Dmitri Pal <dmitri@profian.com>

Removing all push restrictions so that automerge rules work correctly in the enarx organization.